### PR TITLE
Configure automated deployment to GitHub Pages and fix build errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5475,9 +5475,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001707",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
-      "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },
- "scripts": {
-  "start": "react-scripts start",
-  "build": "react-scripts build",
-  "test": "react-scripts test",
-  "eject": "react-scripts eject",
-  "tailwind": "tailwindcss -i ./src/index.css -o ./src/output.css --watch",
-   "deploy": "gh-pages -d build"
-},
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject",
+    "tailwind": "tailwindcss -i ./src/index.css -o ./src/output.css --watch",
+    "deploy": "gh-pages -d build"
+  },
   "eslintConfig": {
     "extends": [
       "react-app",

--- a/src/App.js
+++ b/src/App.js
@@ -38,7 +38,7 @@ const experiences = [
 
 const Portfolio = () => {
   const [spotifyTrack, setSpotifyTrack] = useState(null);
-  const [exploring, setExploring] = useState([
+  const [exploring] = useState([
     { title: "Event-Driven Microservices", link: "https://www.distributed-systems.net/index.php/books/ds4/" },
    
   ]);


### PR DESCRIPTION
- Removed `CNAME` file and updated `homepage` in `package.json` for direct GitHub Pages hosting.
- Created a GitHub Actions workflow for automated building and deployment.
- Fixed an ESLint warning in `src/App.js` (unused variable) that was blocking CI builds.
- Updated the Browserslist database to resolve the `caniuse-lite` warning.
- Updated `src/App.test.js` to match site content and ensure passing builds.